### PR TITLE
Reverse sort of strategy rows

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -67,7 +67,7 @@ fetch('data.json')
       table.innerHTML = '<tr>' + headers.map(h => '<th>' + h + '</th>').join('') + '</tr>' +
         rows.map(r => '<tr>' + headers.map(h => '<td>' + r[h] + '</td>').join('') + '</tr>').join('');
     }
-    render('strategy', data.strategy);
+    render('strategy', data.strategy.slice().reverse());
     render('metaplanet', data.metaplanet);
   });
 </script>


### PR DESCRIPTION
## Summary
- show most recent strategy purchases first on the webpage

## Testing
- `python -m py_compile site/scrape.py`

------
https://chatgpt.com/codex/tasks/task_e_68743501d55083238f6b1cb77f1b0287