### PR TITLE
Add MARA scraping

### DIFF
--- a/data.json
+++ b/data.json
@@ -680,5 +680,337 @@
       "avg_price_usd": 66018.0,
       "total_cost_usd": 6460000.0
     }
+  ],
+  "mara": [
+    {
+      "date": "2020-12-31",
+      "btc": 126.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-01-25",
+      "btc": 4812.66,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-03-15",
+      "btc": 128.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-05-06",
+      "btc": 257.34000000000015,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-06-30",
+      "btc": 460.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-09-30",
+      "btc": 1251.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2021-12-31",
+      "btc": 1098.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2022-02-28",
+      "btc": 823.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2022-03-31",
+      "btc": 418.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2022-06-30",
+      "btc": 681.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2022-09-30",
+      "btc": 615.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2022-12-31",
+      "btc": 1562.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-03-31",
+      "btc": 74.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-05-01",
+      "btc": 102.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-05-31",
+      "btc": 691.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-06-30",
+      "btc": 279.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-07-31",
+      "btc": 426.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-08-31",
+      "btc": 322.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-09-30",
+      "btc": 440.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-11-15",
+      "btc": 330.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2023-12-31",
+      "btc": 1448.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-01-31",
+      "btc": 567.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-02-29",
+      "btc": 1189.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-03-31",
+      "btc": 451.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-04-30",
+      "btc": 250.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-05-31",
+      "btc": 226.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-06-30",
+      "btc": 679.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-07-25",
+      "btc": 1464.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-08-14",
+      "btc": 5000.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-08-31",
+      "btc": 945.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-09-14",
+      "btc": 255.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-10-02",
+      "btc": 642.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-10-31",
+      "btc": 720.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-11-22",
+      "btc": 6313.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-11-27",
+      "btc": 919.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-11-30",
+      "btc": 165.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-12-06",
+      "btc": 1423.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-12-10",
+      "btc": 4053.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2024-12-19",
+      "btc": 3959.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-01-03",
+      "btc": 499.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-02-03",
+      "btc": 766.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-03-10",
+      "btc": 715.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-04-03",
+      "btc": 1226.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-04-30",
+      "btc": 637.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-05-30",
+      "btc": 100.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-05-30",
+      "btc": 903.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-05-31",
+      "btc": 39.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-02",
+      "btc": 49.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-05",
+      "btc": 83.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-08",
+      "btc": 64.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-16",
+      "btc": 168.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-22",
+      "btc": 135.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-06-29",
+      "btc": 181.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-07-01",
+      "btc": 81.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    },
+    {
+      "date": "2025-07-03",
+      "btc": 60.0,
+      "avg_price_usd": null,
+      "total_cost_usd": null
+    }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
     <option value="all">All</option>
     <option value="Strategy">Strategy</option>
     <option value="Metaplanet">Metaplanet</option>
+    <option value="Mara">Mara</option>
   </select>
   <table id="purchases"></table>
 </div>
@@ -110,7 +111,8 @@
 
       const allRows = [
         ...data.strategy.map(r => ({ ...r, company: 'Strategy' })),
-        ...data.metaplanet.map(r => ({ ...r, company: 'Metaplanet' }))
+        ...data.metaplanet.map(r => ({ ...r, company: 'Metaplanet' })),
+        ...data.mara.map(r => ({ ...r, company: 'Mara' }))
       ];
 
       allRows.sort((a, b) => new Date(b.date) - new Date(a.date));


### PR DESCRIPTION
## Summary
- scrape MARA balance sheet history
- derive purchase events from balance deltas
- add MARA option to filter in UI
- include new MARA records in data.json

## Testing
- `python scrape.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c2ee7e488323b9954e9809774229