### PR TITLE
Change scrape schedule to half hour

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,7 +2,7 @@ name: Scrape
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- run the scraping workflow every 30 minutes

## Testing
- `python -m py_compile scrape.py && node -c parse_mara.js`

------
https://chatgpt.com/codex/tasks/task_e_6876a2fcf61083238dfd7f74025ccb91