### PR TITLE
Fix scheduled push permission

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/5 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow workflow writes by configuring permissions

## Testing
- `python -m py_compile scrape.py`

------
https://chatgpt.com/codex/tasks/task_e_6876af25349c83239b7452b3e11c7ca3