### PR TITLE
Add cumulative BTC chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
   <select id="company-filter">
     <option value="all">All</option>
   </select>
-  <canvas id="btcChart" height="300"></canvas>
+  <canvas id="btcChart" height="180"></canvas>
   <table id="purchases"></table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,14 @@
     border-radius: 4px;
     font-size: 1em;
   }
+
+  #btcChart {
+    max-width: 100%;
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 4px;
+    margin-bottom: 40px;
+  }
 </style>
 </head>
 <body>
@@ -66,8 +74,10 @@
   <select id="company-filter">
     <option value="all">All</option>
   </select>
+  <canvas id="btcChart" height="300"></canvas>
   <table id="purchases"></table>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
   fetch('data.json')
     .then(r => r.json())
@@ -153,6 +163,44 @@
 
       allRows.sort((a, b) => new Date(b.date) - new Date(a.date));
 
+      const ctx = document.getElementById('btcChart').getContext('2d');
+      let chart;
+
+      function updateChart(rows) {
+        const sorted = rows.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
+        const labels = [];
+        const dataPoints = [];
+        let cumulative = 0;
+        sorted.forEach(r => {
+          cumulative += Number(r.btc);
+          labels.push(new Date(r.date).toLocaleDateString('en-US'));
+          dataPoints.push(cumulative);
+        });
+        if (chart) chart.destroy();
+        chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [{
+              label: 'Cumulative BTC',
+              data: dataPoints,
+              borderColor: '#F7931A',
+              backgroundColor: 'rgba(247,147,26,0.2)',
+              tension: 0.1,
+            }]
+          },
+          options: {
+            plugins: {
+              legend: { labels: { color: '#eee' } }
+            },
+            scales: {
+              x: { ticks: { color: '#eee' } },
+              y: { ticks: { color: '#eee' } }
+            }
+          }
+        });
+      }
+
       function renderFiltered() {
         let rows = allRows;
         const val = filterEl.value;
@@ -160,6 +208,7 @@
           rows = rows.filter(r => r.company === val);
         }
         render('purchases', rows);
+        updateChart(rows);
       }
 
       renderFiltered();


### PR DESCRIPTION
## Summary
- render a line chart with Chart.js showing cumulative BTC purchases
- add styling for chart
- update table rendering function to update chart whenever the company filter changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877ee65c9348323b5b353ce11dfb6d5