### PR TITLE
Add BTC flow panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,14 @@
     background: #1e1e1e;
   }
 
-  #company-filter {
-    margin-left: 10px;
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     margin-bottom: 10px;
+  }
+
+  #company-filter {
     padding: 6px 12px;
     background: #3a3a3a;
     color: #fff;
@@ -65,15 +70,33 @@
     border-radius: 4px;
     margin-bottom: 40px;
   }
+
+  #flow-panel {
+    display: flex;
+    gap: 10px;
+  }
+
+  .flow-card {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 8px 12px;
+  }
 </style>
 </head>
 <body>
 <div class="container">
   <h1>Bitcoin Treasury Purchases</h1>
-  <label for="company-filter">Company:</label>
-  <select id="company-filter">
-    <option value="all">All</option>
-  </select>
+  <div class="controls">
+    <label for="company-filter">Company:</label>
+    <select id="company-filter">
+      <option value="all">All</option>
+    </select>
+    <div id="flow-panel">
+      <div class="flow-card" id="mined-card"></div>
+      <div class="flow-card" id="purchased-card"></div>
+    </div>
+  </div>
   <canvas id="btcChart" height="180"></canvas>
   <table id="purchases"></table>
 </div>
@@ -143,6 +166,8 @@
       }
 
       const filterEl = document.getElementById('company-filter');
+      const minedCard = document.getElementById('mined-card');
+      const purchasedCard = document.getElementById('purchased-card');
       const allRows = [];
       Object.keys(data).forEach(key => {
         const name = key.length <= 3 ? key.toUpperCase() :
@@ -165,6 +190,51 @@
 
       const ctx = document.getElementById('btcChart').getContext('2d');
       let chart;
+
+      const halvingSchedule = [
+        { date: '2012-11-28', reward: 25 },
+        { date: '2016-07-09', reward: 12.5 },
+        { date: '2020-05-11', reward: 6.25 },
+        { date: '2024-04-20', reward: 3.125 },
+      ];
+
+      function rewardOn(date) {
+        let reward = 50;
+        for (const h of halvingSchedule) {
+          if (date >= new Date(h.date)) {
+            reward = h.reward;
+          } else {
+            break;
+          }
+        }
+        return reward;
+      }
+
+      function minedLast30Days() {
+        const now = new Date();
+        let total = 0;
+        for (let i = 0; i < 30; i++) {
+          const d = new Date(now);
+          d.setDate(d.getDate() - i);
+          total += 144 * rewardOn(d);
+        }
+        return total;
+      }
+
+      function updateFlow(rows) {
+        const cutoff = new Date();
+        cutoff.setDate(cutoff.getDate() - 30);
+        const purchased = rows.reduce((sum, r) => {
+          const d = new Date(r.date);
+          if (d >= cutoff && Number(r.btc) > 0) {
+            sum += Number(r.btc);
+          }
+          return sum;
+        }, 0);
+        const mined = minedLast30Days();
+        minedCard.innerHTML = `<strong>Mined (30d)</strong><br>\u20BF${mined.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+        purchasedCard.innerHTML = `<strong>Purchased (30d)</strong><br>\u20BF${purchased.toLocaleString('en-US', { maximumFractionDigits: 2 })}`;
+      }
 
       function updateChart(rows) {
         const sorted = rows.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
@@ -209,6 +279,7 @@
         }
         render('purchases', rows);
         updateChart(rows);
+        updateFlow(rows);
       }
 
       renderFiltered();


### PR DESCRIPTION
## Summary
- add a new `flow-panel` to display bitcoin mined versus purchased
- compute block reward per halving and aggregate past 30 days
- show flow data whenever the table is filtered
- align the flow panel next to the company selector and break out mined and purchased values into separate cards

## Testing
- `python -m py_compile scrape.py`
- `node --check parse_mara.js`


------
https://chatgpt.com/codex/tasks/task_e_6878062cc8288323a6ab286f89f7d623