### PR TITLE
Fix Safari dropdown style

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,8 @@
     border: 1px solid #333;
     border-radius: 4px;
     font-size: 1em;
+    -webkit-appearance: none;
+    appearance: none;
   }
 
   #btcChart {


### PR DESCRIPTION
## Summary
- remove Safari's default appearance on the company dropdown

## Testing
- `python -m py_compile scrape.py`
- `node -c parse_mara.js`


------
https://chatgpt.com/codex/tasks/task_e_687fd830d96c8323a02b3b8ec4f393f7