### PR TITLE
Fix date display timezone

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
         function format(value, key) {
           if (key === 'date') {
             return new Date(value).toLocaleDateString('en-US', {
+              timeZone: 'UTC',
               year: 'numeric',
               month: 'short',
               day: 'numeric'
@@ -236,7 +237,7 @@
         let cumulative = 0;
         sorted.forEach(r => {
           cumulative += Number(r.btc);
-          labels.push(new Date(r.date).toLocaleDateString('en-US'));
+          labels.push(new Date(r.date).toLocaleDateString('en-US', { timeZone: 'UTC' }));
           dataPoints.push(cumulative);
         });
         if (chart) chart.destroy();


### PR DESCRIPTION
## Summary
- keep dates consistent with bitcointreasuries.net by forcing UTC locale when formatting

## Testing
- `python3 -m py_compile scrape.py`

------
https://chatgpt.com/codex/tasks/task_e_68800659622483238dc06771654a2d0a