### PR TITLE
Hide total cost on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bitcoin Treasury Purchases</title>
 <link rel="icon" type="image/png" href="favicon.png">
 <style>
@@ -83,6 +84,12 @@
     margin-bottom: 40px;
   }
 
+  @media (max-width: 600px) {
+    .total_cost_usd {
+      display: none;
+    }
+  }
+
 </style>
 </head>
 <body>
@@ -152,13 +159,13 @@
 
         table.innerHTML =
           '<tr>' +
-          headers.map(h => '<th>' + (headerMap[h] || h) + '</th>').join('') +
+          headers.map(h => '<th class="' + h + '">' + (headerMap[h] || h) + '</th>').join('') +
           '</tr>' +
           rows
             .map(r =>
               '<tr>' +
               headers
-                .map(h => '<td>' + format(r[h], h) + '</td>')
+                .map(h => '<td class="' + h + '">' + format(r[h], h) + '</td>')
                 .join('') +
               '</tr>'
             )


### PR DESCRIPTION
## Summary
- add viewport meta tag
- hide total cost column for small screens
- mark total cost cells with a CSS class for easier styling

## Testing
- `git --no-pager diff index.html`

------
https://chatgpt.com/codex/tasks/task_e_68806db3701c8323a08b44201196bd1b