### PR TITLE
UI tweak

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,13 +65,12 @@
   }
 
   #io-wrapper {
-    display: inline-block;
+    display: block;
     white-space: nowrap;
-    vertical-align: middle;
+    padding: 10px 0;
   }
 
   #io-panel {
-    margin-top: -4px;
     padding: 3.7px 12px;
     background: #3a3a3a;
     color: #fff;
@@ -79,7 +78,6 @@
     font-size: 1em;
     display: inline-block;
     white-space: nowrap;
-    vertical-align: middle;   /* or top */
   }
 
   th.date, td.date {
@@ -118,8 +116,8 @@
   <select id="company-filter">
     <option value="all">All</option>
   </select>
-  <span id="io-wrapper">Last 30 days: <span id="io-panel"></span></span>
   <canvas id="btcChart" height="180"></canvas>
+  <span id="io-wrapper">Last 30 days: <span id="io-panel"></span></span>
   <table id="purchases"></table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- reposition the IO panel below the BTC chart
- add padding around the IO panel wrapper

## Testing
- `python -m py_compile scrape.py`
- `node -c parse_mara.js`


------
https://chatgpt.com/codex/tasks/task_e_6881140ad6c88323a865327659c4b72f