### PR TITLE
Add totals panel for bitcoin and return

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,17 @@
     white-space: nowrap;
   }
 
+  #totals-panel {
+    padding: 4px 12px;
+    margin-bottom: 8px;
+    background: #3a3a3a;
+    color: #fff;
+    border-radius: 4px;
+    font-size: 1em;
+    display: inline-block;
+    white-space: nowrap;
+  }
+
   th.date, td.date {
     white-space: nowrap;
   }
@@ -118,6 +129,7 @@
   </select>
   <canvas id="btcChart" height="180"></canvas>
   <span id="io-wrapper">Last 30 days: <span id="io-panel"></span></span>
+  <div id="totals-panel"></div>
   <table id="purchases"></table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -217,6 +229,12 @@
 
       const ctx = document.getElementById('btcChart').getContext('2d');
       let chart;
+      let btcPrice = 0;
+
+      fetch('https://api.coindesk.com/v1/bpi/currentprice/USD.json')
+        .then(r => r.json())
+        .then(d => { btcPrice = d.bpi.USD.rate_float; updateTotalsPanel(allRows); })
+        .catch(() => {});
 
       function blockReward(date) {
         const schedule = [
@@ -262,6 +280,17 @@
           `Mined:&nbsp;₿${mined.toLocaleString('en-US', {maximumFractionDigits:2})}&nbsp;|&nbsp;Purchased:&nbsp;₿${purchased.toLocaleString('en-US', {maximumFractionDigits:2})}`;
       }
 
+      function updateTotalsPanel(rows) {
+        const panel = document.getElementById('totals-panel');
+        const totalBtc = rows.reduce((sum, r) => sum + Number(r.btc), 0);
+        const totalCost = rows.reduce((sum, r) => sum + Number(r.total_cost_usd), 0);
+        const totalValue = btcPrice ? totalBtc * btcPrice : 0;
+        const totalReturn = btcPrice ? totalValue - totalCost : 0;
+        panel.innerHTML =
+          `Total Bitcoin: ₿${totalBtc.toLocaleString('en-US', {maximumFractionDigits:2})}` +
+          ` | Total Return: ${totalReturn.toLocaleString('en-US', {style:'currency', currency:'USD', maximumFractionDigits:0})}`;
+      }
+
       function updateChart(rows) {
         const sorted = rows.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
         const points = [];
@@ -303,6 +332,7 @@
         render('purchases', rows);
         updateChart(rows);
         updateInOutPanel(rows);
+        updateTotalsPanel(rows);
       }
 
       renderFiltered();


### PR DESCRIPTION
## Summary
- add a totals panel to show current bitcoin and return
- fetch BTC price and calculate totals based on filtered data

## Testing
- `python -m py_compile scrape.py`
- `node -c parse_mara.js`


------
https://chatgpt.com/codex/tasks/task_e_688283a8d1e083239f63602e83deb0ec