### PR TITLE
Align totals and IO panels horizontally on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,9 @@
   }
 
   #io-wrapper {
-    display: block;
+    display: inline-block;
     white-space: nowrap;
+    margin-right: 10px;
   }
 
   #io-panel {
@@ -81,8 +82,9 @@
   }
 
   #totals-wrapper {
-    display: block;
+    display: inline-block;
     white-space: nowrap;
+    margin-right: 10px;
   }
 
   #totals-panel {
@@ -118,6 +120,10 @@
     }
     .total_cost_usd {
       display: none;
+    }
+    #io-wrapper,
+    #totals-wrapper {
+      display: block;
     }
   }
 


### PR DESCRIPTION
## Summary
- keep "Total" and "Last 30 days" panels on the same line for wider screens
- stack the panels vertically on small screens

## Testing
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_6882912200808323a8f77f90affde256